### PR TITLE
Convertir ConnectApi en object

### DIFF
--- a/src/main/kotlin/cu/suitetecsa/sdk/nauta/ConnectApi.kt
+++ b/src/main/kotlin/cu/suitetecsa/sdk/nauta/ConnectApi.kt
@@ -2,7 +2,6 @@ package cu.suitetecsa.sdk.nauta
 
 import cu.suitetecsa.sdk.nauta.exception.LoginException
 import cu.suitetecsa.sdk.nauta.exception.LogoutException
-import cu.suitetecsa.sdk.nauta.exception.NautaAttributeException
 import cu.suitetecsa.sdk.nauta.exception.NautaGetInfoException
 import cu.suitetecsa.sdk.nauta.model.DataSession
 import cu.suitetecsa.sdk.nauta.model.NautaConnectInformation
@@ -20,131 +19,79 @@ import cu.suitetecsa.sdk.network.JsoupPortalCommunicator
 import cu.suitetecsa.sdk.network.PortalCommunicator
 import cu.suitetecsa.sdk.util.ExceptionHandler
 
-class ConnectApi private constructor(
-    private val communicator: PortalCommunicator,
-    private val scraper: ConnectPortalScraper
-) {
-    var username: String? = null
-        private set
-    var password: String? = null
-        private set
+object ConnectApi {
+    private var communicator: PortalCommunicator = JsoupPortalCommunicator.Builder().build()
+    private var scraper = JsoupConnectPortalScraper.Builder().build()
 
-    private var actionLogin: String? = null
-    private var wlanUserIp: String? = null
-    private var csrfHw: String? = null
-    private var attributeUUID: String? = null
+    fun withPortalCommunicator(portalCommunicator: PortalCommunicator) {
+        communicator = portalCommunicator
+    }
+
+    fun withPortalScraper(portalScraper: ConnectPortalScraper) {
+        scraper = portalScraper
+    }
 
     val isConnected: Result<Boolean>
-        get() = communicator.performAction(CheckConnection()) { scraper.parseCheckConnections(it.text) }
+        get() = communicator.performRequest(CheckConnection()) { scraper.parseCheckConnections(it.text) }
 
-    var dataSession: DataSession? = null
-        set(value) {
-            field = value
-            username = value?.username
-            csrfHw = value?.csrfHw
-            wlanUserIp = value?.wlanUserIp
-            attributeUUID = value?.attributeUUID
-        }
-
-    val remainingTime: Result<Long>
-        get() = isConnected.mapCatching { isConnected ->
+    fun getRemainingTime(dataSession: DataSession): Result<Long> =
+        isConnected.mapCatching { isConnected ->
             if (!isConnected) {
                 throw NautaGetInfoException(
                     "you are not connected. You need to be connected to get the remaining time."
                 )
             }
-            checkDataSession()
-            checkCredentials()
 
             val action = LoadUserInformation(
-                username,
-                wlanUserIp = wlanUserIp,
-                csrfHw = csrfHw,
-                attributeUUID = attributeUUID,
+                dataSession.username,
+                wlanUserIp = dataSession.wlanUserIp,
+                csrfHw = dataSession.csrfHw,
+                attributeUUID = dataSession.attributeUUID,
                 portal = PortalManager.Connect
             )
-            communicator.performAction(action) { it.text.toSeconds() }.getOrThrow()
+            communicator.performRequest(action) { it.text.toSeconds() }.getOrThrow()
         }
 
-    val connectInformation: Result<NautaConnectInformation>
-        get() = runCatching {
-            checkCredentials()
-            if (csrfHw.isNullOrBlank()) init()
-            val action = LoadUserInformation(username, password, wlanUserIp, csrfHw, portal = PortalManager.Connect)
-            communicator.performAction(action) { scraper.parseNautaConnectInformation(it.text) }.getOrThrow()
-        }
-
-    private fun checkCredentials() {
-        if (username.isNullOrBlank() || password.isNullOrBlank()) {
-            throw NautaAttributeException("username and password are required")
-        }
-    }
-
-    private fun checkDataSession() {
-        if (dataSession == null) throw NautaAttributeException("dataSession cannot be null")
-    }
-
-    private fun init() {
-        val (loginAction, loginData) = communicator.performAction(GetPage("https://$connectDomain")) {
+    private fun init(): Result<Triple<String, String, String>> = runCatching {
+        val (loginAction, loginData) = communicator.performRequest(GetPage("https://$connectDomain:8443")) {
             scraper.parseLoginForm(it.text)
         }.getOrThrow()
-        wlanUserIp = loginData["wlanuserip"] ?: ""
-        csrfHw = loginData["CSRFHW"] ?: ""
-        actionLogin = loginAction
+        Triple(loginAction, loginData["wlanuserip"] ?: "", loginData["CSRFHW"] ?: "")
     }
 
-    fun setCredentials(username: String, password: String) {
-        this.username = username
-        this.password = password
-    }
+    fun getUserInformation(username: String, password: String): Result<NautaConnectInformation> =
+        runCatching {
+            val (_, wlanUserIp, csrfHw) = init().getOrThrow()
+            val action = LoadUserInformation(username, password, wlanUserIp, csrfHw, portal = PortalManager.Connect)
+            communicator.performRequest(action) { scraper.parseNautaConnectInformation(it.text) }.getOrThrow()
+        }
 
-    fun connect(): Result<String> =
+    fun connect(username: String, password: String): Result<DataSession> =
         isConnected.mapCatching { isLoggedIn ->
             val loginExceptionHandler = ExceptionHandler.Builder(LoginException::class.java).build()
             if (isLoggedIn) throw loginExceptionHandler.handleException("Fail to connect", listOf("Already connected"))
-            checkCredentials()
-            init()
 
-            val action = Login(csrfHw, wlanUserIp, username!!, password!!, portal = PortalManager.Connect)
-            val uuid = communicator.performAction(action) { scraper.parseAttributeUUID(it.text) }.getOrThrow()
-            dataSession = DataSession(username!!, csrfHw!!, wlanUserIp!!, uuid)
-            "Connected"
+            val (_, wlanUserIp, csrfHw) = init().getOrThrow()
+
+            val action = Login(csrfHw, wlanUserIp, username, password, portal = PortalManager.Connect)
+            val uuid = communicator.performRequest(action) { scraper.parseAttributeUUID(it.text) }.getOrThrow()
+            DataSession(username, csrfHw, wlanUserIp, uuid)
         }
 
-    fun disconnect(): Result<String> =
+    fun disconnect(dataSession: DataSession): Result<Unit> =
         isConnected.mapCatching { connected ->
             val logoutExceptionHandler = ExceptionHandler.Builder(LogoutException::class.java).build()
             if (!connected) {
                 throw logoutExceptionHandler.handleException("Fail to disconnect", listOf("You are not connected"))
             }
-            checkDataSession()
 
-            val action = Logout(username!!, password!!, csrfHw!!, attributeUUID!!)
-            val isLogout = communicator.performAction(action) { scraper.isSuccessLogout(it.text) }.getOrThrow()
-            if (!isLogout) throw logoutExceptionHandler.handleException("Failed to disconnect", listOf(""))
-            dataSession = null
-            "Disconnected"
-        }
-
-    class Builder {
-        private var communicator: PortalCommunicator? = null
-        private var scraper: ConnectPortalScraper? = null
-
-        fun withCommunicator(communicator: PortalCommunicator): Builder {
-            this.communicator = communicator
-            return this
-        }
-
-        fun withScraper(scraper: ConnectPortalScraper): Builder {
-            this.scraper = scraper
-            return this
-        }
-
-        fun build(): ConnectApi {
-            return ConnectApi(
-                communicator ?: JsoupPortalCommunicator.Builder().build(),
-                scraper ?: JsoupConnectPortalScraper.Builder().build()
+            val action = Logout(
+                dataSession.username,
+                dataSession.wlanUserIp,
+                dataSession.csrfHw,
+                dataSession.attributeUUID
             )
+            val isLogout = communicator.performRequest(action) { scraper.isSuccessLogout(it.text) }.getOrThrow()
+            if (!isLogout) throw logoutExceptionHandler.handleException("Failed to disconnect", listOf(""))
         }
-    }
 }

--- a/src/main/kotlin/cu/suitetecsa/sdk/nauta/UserPortalActionsProvider.kt
+++ b/src/main/kotlin/cu/suitetecsa/sdk/nauta/UserPortalActionsProvider.kt
@@ -35,7 +35,7 @@ class UserPortalActionsProvider private constructor(
 ) {
     private val getInfoExceptionHandler = ExceptionHandler.Builder(NautaGetInfoException::class.java).build()
     private fun loadCsrfToken(actionUrl: String) =
-        communicator.performAction(actionUrl) {
+        communicator.performRequest(actionUrl) {
             tokenParser.parseCsrfToken(errorParser.parseErrors(it.text, "Fail to load csrf token").getOrThrow())
         }.getOrThrow()
 
@@ -43,7 +43,7 @@ class UserPortalActionsProvider private constructor(
         val action = GetSummary(year = year, month = month, type = ActionType.Connections)
         val csrf = loadCsrfToken(action.csrfUrl)
 
-        communicator.performAction(action.copy(csrf = csrf)) {
+        communicator.performRequest(action.copy(csrf = csrf)) {
             summaryParser.parseConnectionsSummary(
                 errorParser.parseErrors(
                     it.text,
@@ -88,7 +88,7 @@ class UserPortalActionsProvider private constructor(
         val action = GetSummary(year = year, month = month, type = ActionType.Recharges)
         val csrf = loadCsrfToken(action.csrfUrl)
 
-        communicator.performAction(action.copy(csrf = csrf)) {
+        communicator.performRequest(action.copy(csrf = csrf)) {
             summaryParser.parseRechargesSummary(
                 errorParser.parseErrors(
                     it.text,
@@ -133,7 +133,7 @@ class UserPortalActionsProvider private constructor(
         val action = GetSummary(year = year, month = month, type = ActionType.Transfers)
         val csrf = loadCsrfToken(action.csrfUrl)
 
-        communicator.performAction(action.copy(csrf = csrf)) {
+        communicator.performRequest(action.copy(csrf = csrf)) {
             summaryParser.parseTransfersSummary(
                 errorParser.parseErrors(
                     it.text,
@@ -178,7 +178,7 @@ class UserPortalActionsProvider private constructor(
         val action = GetSummary(year = year, month = month, type = ActionType.QuotesPaid)
         val csrf = loadCsrfToken(action.csrfUrl)
 
-        communicator.performAction(action.copy(csrf = csrf)) {
+        communicator.performRequest(action.copy(csrf = csrf)) {
             summaryParser.parseQuotesPaidSummary(
                 errorParser.parseErrors(
                     it.text,
@@ -219,13 +219,13 @@ class UserPortalActionsProvider private constructor(
     private fun <T> getActions(action: Action, pageTo: Int, transform: (HttpResponse) -> List<T>) =
         runCatching {
             if (pageTo != 0) {
-                communicator.performAction("${action.url}${action.yearMonthSelected}/${action.count}/$pageTo") {
+                communicator.performRequest("${action.url}${action.yearMonthSelected}/${action.count}/$pageTo") {
                     transform(it)
                 }.getOrThrow()
             } else {
                 val list = mutableListOf<T>()
                 repeat(action.pagesCount) { page ->
-                    communicator.performAction(
+                    communicator.performRequest(
                         "${action.url}${action.yearMonthSelected}/" +
                             "${action.count}${if (page > 0) "/${page + 1}" else ""}"
                     ) {

--- a/src/main/kotlin/cu/suitetecsa/sdk/nauta/UserPortalAuthApi.kt
+++ b/src/main/kotlin/cu/suitetecsa/sdk/nauta/UserPortalAuthApi.kt
@@ -57,7 +57,7 @@ class UserPortalAuthApi private constructor(
      * @return the captcha image
      */
     val captchaImage: Result<ByteArray>
-        get() = communicator.performAction(GetCaptcha) { it.content }
+        get() = communicator.performRequest(GetCaptcha) { it.content }
 
     /**
      * Load the user information for the user portal authentication API
@@ -67,13 +67,13 @@ class UserPortalAuthApi private constructor(
     val userInformation: Result<NautaUser>
         get() = runCatching {
             if (csrf.isBlank()) throw NotLoggedInException("Failed to get user information :: You are not logged in")
-            communicator.performAction(LoadUserInformation(portal = PortalManager.User)) {
+            communicator.performRequest(LoadUserInformation(portal = PortalManager.User)) {
                 scraper.parseNautaUser(it.text)
             }.getOrThrow().apply { isNautaHome = !offer.isNullOrEmpty() }
         }
 
     private fun loadCsrf(action: Action) {
-        csrf = communicator.performAction(action.url) {
+        csrf = communicator.performRequest(action.url) {
             scraper.parseCsrfToken(it.text)
         }.getOrThrow()
     }
@@ -92,7 +92,7 @@ class UserPortalAuthApi private constructor(
             method = HttpMethod.GET
         )
         if (csrf.isBlank()) loadCsrf(action)
-        communicator.performAction(action.copy(csrf = csrf, method = HttpMethod.POST)) {
+        communicator.performRequest(action.copy(csrf = csrf, method = HttpMethod.POST)) {
             scraper.parseNautaUser(it.text, ExceptionHandler.Builder(LoginException::class.java).build())
         }.getOrThrow().apply { isNautaHome = !offer.isNullOrEmpty() }
     }

--- a/src/main/kotlin/cu/suitetecsa/sdk/nauta/UserPortalBalanceHandler.kt
+++ b/src/main/kotlin/cu/suitetecsa/sdk/nauta/UserPortalBalanceHandler.kt
@@ -24,7 +24,7 @@ class UserPortalBalanceHandler private constructor(
     private val tokenParser: TokenParser
 ) {
     private fun loadCsrfToken(action: Action) =
-        communicator.performAction("https://www.portal.nauta.cu${action.csrfUrl ?: action.url}") {
+        communicator.performRequest("https://www.portal.nauta.cu${action.csrfUrl ?: action.url}") {
             tokenParser.parseCsrfToken(errorParser.parseErrors(it.text, "Fail to load csrf token").getOrThrow())
         }.getOrThrow()
 
@@ -37,7 +37,7 @@ class UserPortalBalanceHandler private constructor(
         val action = TopUpBalance(rechargeCode = rechargeCode, method = HttpMethod.GET)
         val topUpExceptionHandle = ExceptionHandler.Builder(TopUpBalanceException::class.java).build()
 
-        communicator.performAction(action.copy(csrf = loadCsrfToken(action), method = HttpMethod.POST)) {
+        communicator.performRequest(action.copy(csrf = loadCsrfToken(action), method = HttpMethod.POST)) {
             errorParser.parseErrors(it.text, "Fail to top up balance", topUpExceptionHandle).getOrThrow()
         }.getOrThrow()
         Unit
@@ -59,7 +59,7 @@ class UserPortalBalanceHandler private constructor(
         )
         val transferFundsExceptionHandle = ExceptionHandler.Builder(TransferFundsException::class.java).build()
 
-        communicator.performAction(action.copy(csrf = loadCsrfToken(action), method = HttpMethod.POST)) {
+        communicator.performRequest(action.copy(csrf = loadCsrfToken(action), method = HttpMethod.POST)) {
             errorParser.parseErrors(it.text, "Fail to transfer funds", transferFundsExceptionHandle).getOrThrow()
         }.getOrThrow()
         Unit

--- a/src/main/kotlin/cu/suitetecsa/sdk/nauta/UserPortalPasswordManager.kt
+++ b/src/main/kotlin/cu/suitetecsa/sdk/nauta/UserPortalPasswordManager.kt
@@ -21,7 +21,7 @@ class UserPortalPasswordManager private constructor(
     private val tokenParser: TokenParser
 ) {
     private fun loadCsrfToken(action: Action) =
-        communicator.performAction(action.url) {
+        communicator.performRequest(action.url) {
             tokenParser.parseCsrfToken(errorParser.parseErrors(it.text, "Fail to load csrf token").getOrThrow())
         }.getOrThrow()
 
@@ -35,7 +35,7 @@ class UserPortalPasswordManager private constructor(
         val action = ChangePassword(oldPassword = oldPassword, newPassword = newPassword)
         val changePasswordExceptionHandler = ExceptionHandler.Builder(NautaChangePasswordException::class.java).build()
 
-        communicator.performAction(action.copy(csrf = loadCsrfToken(action))) {
+        communicator.performRequest(action.copy(csrf = loadCsrfToken(action))) {
             errorParser.parseErrors(it.text, "Fail to change password", changePasswordExceptionHandler).getOrThrow()
         }.getOrThrow()
         Unit
@@ -51,7 +51,7 @@ class UserPortalPasswordManager private constructor(
         val action = ChangePassword(oldPassword = oldPassword, newPassword = newPassword, changeMail = true)
         val changePasswordExceptionHandler = ExceptionHandler.Builder(NautaChangePasswordException::class.java).build()
 
-        communicator.performAction(action.copy(csrf = loadCsrfToken(action))) {
+        communicator.performRequest(action.copy(csrf = loadCsrfToken(action))) {
             errorParser.parseErrors(it.text, "Fail to change password", changePasswordExceptionHandler).getOrThrow()
         }.getOrThrow()
         Unit

--- a/src/main/kotlin/cu/suitetecsa/sdk/network/JsoupPortalCommunicator.kt
+++ b/src/main/kotlin/cu/suitetecsa/sdk/network/JsoupPortalCommunicator.kt
@@ -39,7 +39,7 @@ class JsoupPortalCommunicator(private val session: Session) : PortalCommunicator
      * @param transform La función de transformación que se aplicará a la respuesta del portal.
      * @return Objeto `ResultType` que encapsula el resultado de la acción realizada y transformada.
      */
-    override fun <T> performAction(action: Action, transform: (HttpResponse) -> T): Result<T> =
+    override fun <T> performRequest(action: Action, transform: (HttpResponse) -> T): Result<T> =
         handleResponse(
             url = action.url,
             data = action.data,
@@ -56,7 +56,7 @@ class JsoupPortalCommunicator(private val session: Session) : PortalCommunicator
      * @param transform La función de transformación que se aplicará a la respuesta del portal.
      * @return Objeto `ResultType` que encapsula el resultado de la acción realizada y transformada.
      */
-    override fun <T> performAction(url: String, transform: (HttpResponse) -> T): Result<T> =
+    override fun <T> performRequest(url: String, transform: (HttpResponse) -> T): Result<T> =
         handleResponse(url = url, transform = transform)
 
     /**

--- a/src/main/kotlin/cu/suitetecsa/sdk/network/PortalCommunicator.kt
+++ b/src/main/kotlin/cu/suitetecsa/sdk/network/PortalCommunicator.kt
@@ -12,7 +12,7 @@ interface PortalCommunicator {
      * @param transform La función de transformación que se aplicará a la respuesta del portal.
      * @return Objeto `ResultType` que encapsula el resultado de la acción realizada y transformada.
      */
-    fun <T> performAction(action: Action, transform: (HttpResponse) -> T): Result<T>
+    fun <T> performRequest(action: Action, transform: (HttpResponse) -> T): Result<T>
 
     /**
      * Realiza una acción en el portal de conexión y transforma la respuesta según la función dada.
@@ -21,5 +21,5 @@ interface PortalCommunicator {
      * @param transform La función de transformación que se aplicará a la respuesta del portal.
      * @return Objeto `ResultType` que encapsula el resultado de la acción realizada y transformada.
      */
-    fun <T> performAction(url: String, transform: (HttpResponse) -> T): Result<T>
+    fun <T> performRequest(url: String, transform: (HttpResponse) -> T): Result<T>
 }

--- a/src/test/kotlin/cu/suitetecsa/sdk/nauta/ConnectApiTest.kt
+++ b/src/test/kotlin/cu/suitetecsa/sdk/nauta/ConnectApiTest.kt
@@ -2,7 +2,6 @@ package cu.suitetecsa.sdk.nauta
 
 import cu.suitetecsa.sdk.nauta.exception.LoadInfoException
 import cu.suitetecsa.sdk.nauta.exception.LogoutException
-import cu.suitetecsa.sdk.nauta.exception.NautaAttributeException
 import cu.suitetecsa.sdk.nauta.exception.NautaGetInfoException
 import cu.suitetecsa.sdk.nauta.model.AccountInfo
 import cu.suitetecsa.sdk.nauta.model.DataSession
@@ -18,7 +17,6 @@ import cu.suitetecsa.sdk.network.PortalCommunicator
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -28,37 +26,6 @@ import org.mockito.kotlin.whenever
 
 class ConnectApiTest {
 
-    // Tests that ConnectApi can be instantiated with a PortalCommunicator and a ConnectPortalScraper
-    @Test
-    fun test_instantiation_with_portal_communicator_and_scraper() {
-        // Create mock PortalCommunicator and ConnectPortalScraper
-        val communicator = mock<PortalCommunicator>()
-        val scraper = mock<ConnectPortalScraper>()
-
-        // Instantiate ConnectApi with the mock objects
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
-
-        // Assert that the ConnectApi object is not null
-        assertNotNull(connectApi)
-    }
-
-    // Tests that setCredentials sets the username and password
-    @Test
-    fun test_set_credentials() {
-        // Create a ConnectApi object
-        val connectApi = ConnectApi.Builder().build()
-
-        // Set the credentials
-        connectApi.setCredentials("username", "password")
-
-        // Assert that the username and password are set correctly
-        assertEquals("username", connectApi.username)
-        assertEquals("password", connectApi.password)
-    }
-
     // Tests that connect connects to the Nauta network and returns "Connected"
     @Test
     fun test_connect() {
@@ -67,27 +34,22 @@ class ConnectApiTest {
         val scraper = mock<ConnectPortalScraper>()
 
         // Create a ConnectApi object with the mock objects
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
-
-        // Set the credentials
-        connectApi.setCredentials("username", "password")
+        ConnectApi.withPortalScraper(scraper)
+        ConnectApi.withPortalCommunicator(communicator)
 
         // Mock the performAction method of the communicator to return a successful Result
         val isConnected = Result.success(false)
         val result = Result.success("AttributeUUID")
 
         whenever(
-            communicator.performAction(any<CheckConnection>(), any<(HttpResponse) -> Boolean>())
+            communicator.performRequest(any<CheckConnection>(), any<(HttpResponse) -> Boolean>())
         ).thenReturn(isConnected)
 
         whenever(
-            communicator.performAction(any<GetPage>(), any<(HttpResponse) -> Pair<String, Map<String, String>>>())
+            communicator.performRequest(any<GetPage>(), any<(HttpResponse) -> Pair<String, Map<String, String>>>())
         ).thenReturn(Result.success(Pair("", mapOf("wlanuserip" to "wlanuserip", "CSRFHW" to "CSRFHW"))))
 
-        whenever(communicator.performAction(any<Login>(), any<(HttpResponse) -> Any>())).thenReturn(result)
+        whenever(communicator.performRequest(any<Login>(), any<(HttpResponse) -> Any>())).thenReturn(result)
 
         whenever(scraper.parseCheckConnections(any())).thenReturn(false)
         whenever(scraper.parseActionForm(any())).thenReturn(Pair("", emptyMap()))
@@ -97,11 +59,14 @@ class ConnectApiTest {
         whenever(scraper.parseAttributeUUID(any())).thenReturn("AttributeUUID")
 
         // Call the connect method
-        val connectResult = connectApi.connect()
+        val connectResult = ConnectApi.connect("username", "password")
 
         // Assert that the connectResult is successful and returns "Connected"
         assertTrue(connectResult.isSuccess)
-        assertEquals("Connected", connectResult.getOrNull())
+        assertEquals("wlanuserip", connectResult.getOrNull()?.wlanUserIp)
+        assertEquals("CSRFHW", connectResult.getOrNull()?.csrfHw)
+        assertEquals("username", connectResult.getOrNull()?.username)
+        assertEquals("AttributeUUID", connectResult.getOrNull()?.attributeUUID)
     }
 
     // Tests that disconnect disconnects from the Nauta network and returns "Disconnected"
@@ -112,27 +77,22 @@ class ConnectApiTest {
         val scraper = mock<ConnectPortalScraper>()
 
         // Create a ConnectApi object with the mock objects
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
-
-        // Set the credentials
-        connectApi.setCredentials("username", "password")
+        ConnectApi.withPortalScraper(scraper)
+        ConnectApi.withPortalCommunicator(communicator)
 
         // Set the dataSession
-        connectApi.dataSession = DataSession("username", "csrfHw", "wlanUserIp", "attributeUUID")
+        val dataSession = DataSession("username", "csrfHw", "wlanUserIp", "attributeUUID")
 
         // Mock the performAction method of the communicator to return a successful Result
         val result = Result.success(true)
-        whenever(communicator.performAction(any<Action>(), any<(HttpResponse) -> Any>())).thenReturn(result)
+        whenever(communicator.performRequest(any<Action>(), any<(HttpResponse) -> Any>())).thenReturn(result)
 
         // Call the disconnect method
-        val disconnectResult = connectApi.disconnect()
+        val disconnectResult = ConnectApi.disconnect(dataSession)
 
         // Assert that the disconnectResult is successful and returns "Disconnected"
         assertTrue(disconnectResult.isSuccess)
-        assertEquals("Disconnected", disconnectResult.getOrNull())
+        assertEquals(Unit, disconnectResult.getOrNull())
     }
 
     // Tests that isConnected returns true if connected to the Nauta network
@@ -143,17 +103,15 @@ class ConnectApiTest {
         val scraper = mock<ConnectPortalScraper>()
 
         // Create a ConnectApi object with the mock objects
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
+        ConnectApi.withPortalScraper(scraper)
+        ConnectApi.withPortalCommunicator(communicator)
 
         // Mock the performAction method of the communicator to return a successful Result
         val result = Result.success(true)
-        whenever(communicator.performAction(any<Action>(), any<(HttpResponse) -> Any>())).thenReturn(result)
+        whenever(communicator.performRequest(any<Action>(), any<(HttpResponse) -> Any>())).thenReturn(result)
 
         // Call the isConnected property
-        val isConnectedResult = connectApi.isConnected
+        val isConnectedResult = ConnectApi.isConnected
 
         // Assert that the isConnectedResult is successful and returns true
         assertTrue(isConnectedResult.isSuccess)
@@ -168,29 +126,24 @@ class ConnectApiTest {
         val scraper = mock<ConnectPortalScraper>()
 
         // Create a ConnectApi object with the mock objects
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
-
-        // Set the credentials
-        connectApi.setCredentials("username", "password")
+        ConnectApi.withPortalScraper(scraper)
+        ConnectApi.withPortalCommunicator(communicator)
 
         // Set the dataSession
-        connectApi.dataSession = DataSession("username", "csrfHw", "wlanUserIp", "attributeUUID")
+        val dataSession = DataSession("username", "csrfHw", "wlanUserIp", "attributeUUID")
 
         // Mock the performAction method of the communicator to return a successful Result
         val isConnected = Result.success(true)
         val result = Result.success(3600L)
         whenever(
-            communicator.performAction(any<CheckConnection>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<CheckConnection>(), any<(HttpResponse) -> Any>())
         ).thenReturn(isConnected)
         whenever(
-            communicator.performAction(any<LoadUserInformation>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<LoadUserInformation>(), any<(HttpResponse) -> Any>())
         ).thenReturn(result)
 
         // Call the remainingTime property
-        val remainingTimeResult = connectApi.remainingTime
+        val remainingTimeResult = ConnectApi.getRemainingTime(dataSession)
 
         // Assert that the remainingTimeResult is successful and returns the remaining time in seconds
         assertTrue(remainingTimeResult.isSuccess)
@@ -207,7 +160,8 @@ class ConnectApiTest {
         val scraper = mock<ConnectPortalScraper>()
 
         // Create a ConnectApi instance with the mock objects
-        val connectApi = ConnectApi.Builder().withCommunicator(communicator).withScraper(scraper).build()
+        ConnectApi.withPortalScraper(scraper)
+        ConnectApi.withPortalCommunicator(communicator)
 
         // Set up the mock objects to return the expected values
         val expectedConnectInformation = NautaConnectInformation(
@@ -216,57 +170,25 @@ class ConnectApiTest {
         )
 
         whenever(
-            communicator.performAction(
+            communicator.performRequest(
                 any<CheckConnection>(),
                 any<(HttpResponse) -> Pair<String, Map<String, String>>>()
             )
         ).thenReturn(Result.success(Pair("", emptyMap())))
 
         whenever(
-            communicator.performAction(any<GetPage>(), any<(HttpResponse) -> Pair<String, Map<String, String>>>())
+            communicator.performRequest(any<GetPage>(), any<(HttpResponse) -> Pair<String, Map<String, String>>>())
         ).thenReturn(Result.success(Pair("", mapOf("wlanuserip" to "wlanuserip", "CSRFHW" to "CSRFHW"))))
 
         whenever(
-            communicator.performAction(any<LoadUserInformation>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<LoadUserInformation>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success(expectedConnectInformation))
 
-        connectApi.setCredentials("username", "password")
-
         // Call the connectInformation function
-        val result = connectApi.connectInformation
+        val result = ConnectApi.getUserInformation("username", "password")
 
         // Assert that the result is the expected NautaConnectInformation
         assertEquals(Result.success(expectedConnectInformation), result)
-    }
-
-    // Test that the connect function throws a NautaAttributeException if the username or password is null or blank.
-    @Test
-    fun test_connect_throws_NautaAttributeException_if_username_or_password_is_null_or_blank() {
-        // Create mock PortalCommunicator and ConnectPortalScraper
-        val communicator = mock<PortalCommunicator>()
-        val scraper = mock<ConnectPortalScraper>()
-
-        // Create a ConnectApi object with the mock objects
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
-
-        // Arrange
-        val username = ""
-        val password = ""
-        connectApi.setCredentials(username, password)
-
-        whenever(
-            communicator.performAction(any<CheckConnection>(), any<(HttpResponse) -> Boolean>())
-        ).thenReturn(Result.success(false))
-
-        // Act
-        val result = connectApi.connect()
-
-        // Assert
-        assertTrue(result.isFailure)
-        assertTrue(result.exceptionOrNull() is NautaAttributeException)
     }
 
     // Test that the connect function throws a LoadInfoException if the attributeUUID cannot be parsed
@@ -279,18 +201,16 @@ class ConnectApiTest {
         val scraper = mockk<ConnectPortalScraper>()
 
         // Create a ConnectApi instance with the mocks
-        val connectApi = ConnectApi.Builder().withCommunicator(communicator).withScraper(scraper).build()
+        ConnectApi.withPortalScraper(scraper)
+        ConnectApi.withPortalCommunicator(communicator)
 
         // Set up the mocks to return the necessary values
         every {
-            communicator.performAction(any<Action>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<Action>(), any<(HttpResponse) -> Any>())
         } throws LoadInfoException("Failed to parse attributeUUID")
 
-        // Set the credentials
-        connectApi.setCredentials("username", "password")
-
         // Assert that connect throws a LoadInfoException
-        assertThrows<LoadInfoException> { connectApi.connect() }
+        assertThrows<LoadInfoException> { ConnectApi.connect("", "") }
     }
 
     // Test that the disconnect function throws a LogoutException if the user is not connected.
@@ -299,45 +219,15 @@ class ConnectApiTest {
         // Arrange
         val communicator = mock<PortalCommunicator>()
         val scraper = mock<ConnectPortalScraper>()
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
+        ConnectApi.withPortalScraper(scraper)
+        ConnectApi.withPortalCommunicator(communicator)
 
-        val username = "test_username"
-        val password = "test_password"
-        connectApi.setCredentials(username, password)
-
-        whenever(communicator.performAction(any<CheckConnection>(), any<(HttpResponse) -> Any>()))
+        whenever(communicator.performRequest(any<CheckConnection>(), any<(HttpResponse) -> Any>()))
             .thenReturn(Result.success(false))
 
         // Act and Assert
         assertThrows<LogoutException> {
-            connectApi.disconnect().onFailure { throw it }
-        }
-    }
-
-    // Test that the disconnect function throws a NautaAttributeException if the dataSession is null
-    @Test
-    fun test_disconnect_throws_exception_if_dataSession_is_null() {
-        // Arrange
-        val communicator = mock<PortalCommunicator>()
-        val scraper = mock<ConnectPortalScraper>()
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
-
-        // Mock the performAction function of the communicator to return a Result.success with a true value
-        whenever(
-            communicator.performAction(any<Action>(), any<(HttpResponse) -> Any>())
-        ).thenReturn(
-            Result.success(true)
-        )
-
-        // Act and Assert
-        assertThrows<NautaAttributeException> {
-            connectApi.disconnect().onFailure { throw it }
+            ConnectApi.disconnect(DataSession("", "", "", "")).onFailure { throw it }
         }
     }
 
@@ -351,75 +241,17 @@ class ConnectApiTest {
         val scraper = mock<ConnectPortalScraper>()
 
         // Create an instance of ConnectApi with the mock objects
-        val connectApi = ConnectApi.Builder().withCommunicator(communicator).withScraper(scraper).build()
-
-        // Set the username and password
-        connectApi.setCredentials("username", "password")
+        ConnectApi.withPortalScraper(scraper)
+        ConnectApi.withPortalCommunicator(communicator)
 
         // Mock the performAction function of the communicator to return a Result.failure with a NautaGetInfoException
         whenever(
-            communicator.performAction(any<Action>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<Action>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success(false))
 
         // Call the remainingTime function and assert that it throws a NautaGetInfoException
-        assertThrows<NautaGetInfoException> { connectApi.remainingTime.onFailure { throw it } }
-    }
-
-    // Test that the remainingTime function throws a NautaAttributeException if the dataSession is null
-    @Test
-    fun test_remainingTimeThrowsExceptionIfDataSessionIsNull() {
-        // Arrange
-        val communicator = mock<PortalCommunicator>()
-        val scraper = mock<ConnectPortalScraper>()
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
-
-        whenever(communicator.performAction(any<CheckConnection>(), any<(HttpResponse) -> Any>()))
-            .thenReturn(Result.success(true))
-
-        // Act and Assert
-        assertThrows<NautaAttributeException> {
-            connectApi.remainingTime.onFailure { throw it }
-        }
-    }
-
-    // Test that the connectInformation function throws a NautaAttributeException if the username or password is null
-    // or blank.
-    @Test
-    fun test_connectInformation_throws_NautaAttributeException_if_username_or_password_is_null_or_blank() {
-        // Arrange
-        val username = ""
-        val password = ""
-        val communicator = mock<PortalCommunicator>()
-        val scraper = mock<ConnectPortalScraper>()
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
-
-        // Act and Assert
-        assertThrows<NautaAttributeException> {
-            connectApi.setCredentials(username, password)
-            connectApi.connectInformation.onFailure { throw it }
-        }
-    }
-
-    // Test that the connectInformation function throws a NautaAttributeException if csrfHw is null or blank
-    @Test
-    fun test_connectInformation_throws_NautaAttributeException_if_csrfHw_is_null_or_blank() {
-        // Arrange
-        val communicator = mockk<PortalCommunicator>()
-        val scraper = mockk<ConnectPortalScraper>()
-        val connectApi = ConnectApi.Builder()
-            .withCommunicator(communicator)
-            .withScraper(scraper)
-            .build()
-
-        // Act and Assert
-        assertThrows<NautaAttributeException> {
-            connectApi.connectInformation.onFailure { throw it }
+        assertThrows<NautaGetInfoException> {
+            ConnectApi.getRemainingTime(DataSession("", "", "", "")).onFailure { throw it }
         }
     }
 }

--- a/src/test/kotlin/cu/suitetecsa/sdk/nauta/UserPortalActionsProviderTest.kt
+++ b/src/test/kotlin/cu/suitetecsa/sdk/nauta/UserPortalActionsProviderTest.kt
@@ -50,9 +50,9 @@ class UserPortalActionsProviderTest {
         val csrfToken = "csrf_token"
         val connectionsSummary = ConnectionsSummary(5, "", 0L, 0f, 0.0, 0.0, 0.0)
 
-        whenever(communicator.performAction(eq("https://www.portal.nauta.cu$actionUrl"), any<(AnyTransform)>()))
+        whenever(communicator.performRequest(eq("https://www.portal.nauta.cu$actionUrl"), any<(AnyTransform)>()))
             .thenReturn(Result.success(csrfToken))
-        whenever(communicator.performAction(any<GetSummary>(), any<(AnyTransform)>())).thenReturn(
+        whenever(communicator.performRequest(any<GetSummary>(), any<(AnyTransform)>())).thenReturn(
             Result.success(connectionsSummary)
         )
         whenever(tokenParser.parseCsrfToken(any())).thenReturn(csrfToken)
@@ -61,7 +61,7 @@ class UserPortalActionsProviderTest {
         val result = provider.getConnectionsSummary(year, month)
 
         // Verify the expected method calls and responses
-        verify(communicator).performAction(eq("https://www.portal.nauta.cu$actionUrl"), any<(AnyTransform)>())
+        verify(communicator).performRequest(eq("https://www.portal.nauta.cu$actionUrl"), any<(AnyTransform)>())
 
         // Assert the result
         assertTrue(result.isSuccess)
@@ -92,14 +92,17 @@ class UserPortalActionsProviderTest {
         val csrfToken = "csrf_token"
         val connections = listOf<Connection>()
 
-        whenever(communicator.performAction(any<String>(), any<AnyTransform>())).thenReturn(Result.success(csrfToken))
+        whenever(communicator.performRequest(any<String>(), any<AnyTransform>())).thenReturn(Result.success(csrfToken))
 
         // Call the method under test
         val result = provider.getConnections(summary)
 
         // Verify the expected method calls and responses
         verify(communicator)
-            .performAction(eq("https://www.portal.nauta.cu/useraaa/service_detail_list/2023-09/5"), any<AnyTransform>())
+            .performRequest(
+                eq("https://www.portal.nauta.cu/useraaa/service_detail_list/2023-09/5"),
+                any<AnyTransform>()
+            )
 
         // Assert the result
         assertTrue(result.isSuccess)
@@ -132,10 +135,10 @@ class UserPortalActionsProviderTest {
         val csrfToken = "csrf_token"
         val rechargesSummary = RechargesSummary(5, "", 0f)
 
-        whenever(communicator.performAction(any<String>(), any<AnyTransform>())).thenReturn(
+        whenever(communicator.performRequest(any<String>(), any<AnyTransform>())).thenReturn(
             Result.success(csrfToken)
         )
-        whenever(communicator.performAction(any<GetSummary>(), any<AnyTransform>())).thenReturn(
+        whenever(communicator.performRequest(any<GetSummary>(), any<AnyTransform>())).thenReturn(
             Result.success(rechargesSummary)
         )
 
@@ -143,7 +146,7 @@ class UserPortalActionsProviderTest {
         val result = provider.getRechargesSummary(year, month)
 
         // Verify the expected method calls and responses
-        verify(communicator).performAction(eq("https://www.portal.nauta.cu$actionUrl"), any<AnyTransform>())
+        verify(communicator).performRequest(eq("https://www.portal.nauta.cu$actionUrl"), any<AnyTransform>())
 
         // Assert the result
         assertTrue(result.isSuccess)
@@ -176,10 +179,10 @@ class UserPortalActionsProviderTest {
         val csrfToken = "csrf_token"
         val rechargesSummary = RechargesSummary(5, "", 0f)
 
-        whenever(communicator.performAction(any<String>(), any<AnyTransform>())).thenReturn(
+        whenever(communicator.performRequest(any<String>(), any<AnyTransform>())).thenReturn(
             Result.success(csrfToken)
         )
-        whenever(communicator.performAction(any<GetSummary>(), any<AnyTransform>())).thenReturn(
+        whenever(communicator.performRequest(any<GetSummary>(), any<AnyTransform>())).thenReturn(
             Result.success(rechargesSummary)
         )
 
@@ -187,7 +190,7 @@ class UserPortalActionsProviderTest {
         val result = provider.getRechargesSummary(year, month)
 
         // Verify the expected method calls and responses
-        verify(communicator).performAction(eq("https://www.portal.nauta.cu$actionUrl"), any<AnyTransform>())
+        verify(communicator).performRequest(eq("https://www.portal.nauta.cu$actionUrl"), any<AnyTransform>())
 
         // Assert the result
         assertTrue(result.isSuccess)
@@ -220,16 +223,16 @@ class UserPortalActionsProviderTest {
         val csrfToken = "csrf_token"
         val transfersSummary = TransfersSummary(5, "", 0f)
 
-        whenever(communicator.performAction(any<String>(), any<AnyTransform>()))
+        whenever(communicator.performRequest(any<String>(), any<AnyTransform>()))
             .thenReturn(Result.success(csrfToken))
-        whenever(communicator.performAction(any<GetSummary>(), any<AnyTransform>()))
+        whenever(communicator.performRequest(any<GetSummary>(), any<AnyTransform>()))
             .thenReturn(Result.success(transfersSummary))
 
         // Call the method under test
         val result = provider.getTransfersSummary(year, month)
 
         // Verify the expected method calls and responses
-        verify(communicator).performAction(eq("https://www.portal.nauta.cu$actionUrl"), any<AnyTransform>())
+        verify(communicator).performRequest(eq("https://www.portal.nauta.cu$actionUrl"), any<AnyTransform>())
 
         // Assert the result
         assertTrue(result.isSuccess)

--- a/src/test/kotlin/cu/suitetecsa/sdk/nauta/UserPortalAuthApiTest.kt
+++ b/src/test/kotlin/cu/suitetecsa/sdk/nauta/UserPortalAuthApiTest.kt
@@ -41,10 +41,10 @@ class UserPortalAuthApiTest {
         authApi.setCredentials("username", "password")
 
         whenever(
-            communicator.performAction(any<String>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<String>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success(""))
         whenever(
-            communicator.performAction(any<Login>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<Login>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success(userResult))
 
         // Mock the parseNautaUser function
@@ -73,7 +73,7 @@ class UserPortalAuthApiTest {
             .build()
 
         // Mock the GetCaptcha action
-        whenever(communicator.performAction(any<GetCaptcha>(), any<(HttpResponse) -> Any>())).thenReturn(
+        whenever(communicator.performRequest(any<GetCaptcha>(), any<(HttpResponse) -> Any>())).thenReturn(
             Result.success(ByteArray(0))
         )
 
@@ -102,12 +102,12 @@ class UserPortalAuthApiTest {
         // Set the CSRF token
         authApi.setCredentials("username", "password")
         whenever(
-            communicator.performAction(any<String>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<String>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success("csrf"))
         authApi.login("captcha")
 
         whenever(
-            communicator.performAction(
+            communicator.performRequest(
                 any<LoadUserInformation>(),
                 any<(HttpResponse) -> Any>()
             )
@@ -169,10 +169,10 @@ class UserPortalAuthApiTest {
         // Set the credentials
         authApi.setCredentials("username", "password")
         whenever(
-            communicator.performAction(any<String>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<String>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success("csrf"))
         whenever(
-            communicator.performAction(any<Login>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<Login>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.failure(LoginException("Invalid credentials")))
 
         // Call the login function and assert the exception

--- a/src/test/kotlin/cu/suitetecsa/sdk/nauta/UserPortalBalanceHandlerTest.kt
+++ b/src/test/kotlin/cu/suitetecsa/sdk/nauta/UserPortalBalanceHandlerTest.kt
@@ -33,10 +33,10 @@ class UserPortalBalanceHandlerTest {
 
         // Mock the necessary behavior of the dependencies
         whenever(
-            communicator.performAction(any<TopUpBalance>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<TopUpBalance>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success(Unit))
         whenever(
-            communicator.performAction(any<String>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<String>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success("csrf_token"))
 
         // Call the method under test
@@ -61,10 +61,10 @@ class UserPortalBalanceHandlerTest {
             .build()
 
         whenever(
-            communicator.performAction(any<TransferFunds>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<TransferFunds>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success(Unit))
         whenever(
-            communicator.performAction(any<String>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<String>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success("csrf_token"))
 
         // Call the method under test
@@ -91,10 +91,10 @@ class UserPortalBalanceHandlerTest {
 
         // Mock the necessary behavior of the dependencies
         whenever(
-            communicator.performAction(any<TransferFunds>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<TransferFunds>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success(Unit))
         whenever(
-            communicator.performAction(any<String>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<String>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success("csrf_token"))
 
         // Call the method under test
@@ -121,10 +121,10 @@ class UserPortalBalanceHandlerTest {
 
         // Mock the necessary behavior of the dependencies
         whenever(
-            communicator.performAction(any<TopUpBalance>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<TopUpBalance>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.failure(TopUpBalanceException("Invalid recharge code")))
         whenever(
-            communicator.performAction(any<String>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<String>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success("csrf_token"))
 
         // Call the method under test
@@ -152,10 +152,10 @@ class UserPortalBalanceHandlerTest {
 
         // Mock the necessary behavior of the dependencies
         whenever(
-            communicator.performAction(any<TransferFunds>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<TransferFunds>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.failure(TransferFundsException("Invalid parameters")))
         whenever(
-            communicator.performAction(any<String>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<String>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success("csrf_token"))
 
         // Call the method under test
@@ -183,10 +183,10 @@ class UserPortalBalanceHandlerTest {
 
         // Mock the necessary behavior of the dependencies
         whenever(
-            communicator.performAction(any<TransferFunds>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<TransferFunds>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.failure(TransferFundsException("Insufficient balance")))
         whenever(
-            communicator.performAction(any<String>(), any<(HttpResponse) -> Any>())
+            communicator.performRequest(any<String>(), any<(HttpResponse) -> Any>())
         ).thenReturn(Result.success("csrf_token"))
 
         // Call the method under test


### PR DESCRIPTION
Esto permite trabajar con la librería de forma maś simplificada. Ahora en vez de crear una instancia de ConnectApi solo debes enfocarte en llamar a la función que realiza la operación deseada pasándole la información requerida.

## Cambios
- ConnectApi es ahora un objeto.
- Se retira la función setCredentials (ahora las funciones que requieran las credeciales la solicitarán)
- La función connect devuelve un objecto DataSession con la información de la sesión.
- Se retira la propiedad remainingTime y se incorpora la función getRemainingTime que requiere un objeto DataSession.
- Se retira la propiedad connectInformation y se incorpora la función getUserInformation que requiere un objeto DataSession.
- La función disconnect ahora requiere un objeto DataSession y ya no returna nada.